### PR TITLE
Tilføj oversatte kommandoer

### DIFF
--- a/bin/git-fastlæg
+++ b/bin/git-fastlæg
@@ -1,0 +1,2 @@
+#!/bin/sh
+git commit "$@"

--- a/bin/git-flet
+++ b/bin/git-flet
@@ -1,0 +1,2 @@
+#!/bin/sh
+git merge "$@"

--- a/bin/git-forgren
+++ b/bin/git-forgren
@@ -1,0 +1,2 @@
+#!/bin/sh
+git branch "$@"

--- a/bin/git-gem
+++ b/bin/git-gem
@@ -1,0 +1,2 @@
+#!/bin/sh
+git stash "$@"

--- a/bin/git-hent
+++ b/bin/git-hent
@@ -1,0 +1,2 @@
+#!/bin/sh
+git fetch "$@"

--- a/bin/git-håndpluk
+++ b/bin/git-håndpluk
@@ -1,0 +1,2 @@
+#!/bin/sh
+git cherry-pick "$@"

--- a/bin/git-klandr
+++ b/bin/git-klandr
@@ -1,0 +1,2 @@
+#!/bin/sh
+git blame "$@"

--- a/bin/git-marker
+++ b/bin/git-marker
@@ -1,0 +1,2 @@
+#!/bin/sh
+git tag "$@"

--- a/bin/git-mos
+++ b/bin/git-mos
@@ -1,0 +1,2 @@
+#!/bin/sh
+git squash "$@"

--- a/bin/git-pod
+++ b/bin/git-pod
@@ -1,0 +1,2 @@
+#!/bin/sh
+git rebase "$@"

--- a/bin/git-skub
+++ b/bin/git-skub
@@ -1,0 +1,2 @@
+#!/bin/sh
+git push "$@"

--- a/bin/git-tilret
+++ b/bin/git-tilret
@@ -1,0 +1,2 @@
+#!/bin/sh
+git amend "$@"

--- a/bin/git-træk
+++ b/bin/git-træk
@@ -1,0 +1,2 @@
+#!/bin/sh
+git pull "$@"


### PR DESCRIPTION
Ideelt ville man bruge git alias, men desværre understøttes ikke danske
tegn såsom Æ, Ø eller Å. Derfor er man nødsaget til at lave små "wrapper
scripts" til hvert alias.

Tilføj bin/ til din PATH og du kan skrive følgende:

    git forgren kommandoer
    git checkout kommandoer
    git fastlæg bin/
    git skub

Listen af alias er ufuldstændig, eks. mangler `git checkout` og `git add`.