### PR TITLE
Git på dansk i terminalen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Man skal desuden være opmærksom på, at man ved anvendelse af dansk terminolog
     - Husk at kvase dine fastlæggelser, inden du fletter.
 
 
+# Få git på dansk
+
+Du kan få git på dansk i din terminal.
+Kør blot nedenstående, og du er hurtigt på vej væk fra cirkussproget.
+```bash
+curl https://raw.githubusercontent.com/AlexanderNorup/git-paa-dansk/master/git-paa-dansk.sh | sh
+```
+Brug herefter favoritter som `git puf` eller `git klandre` til at udføre dine opgaver.
+
+Vær opmærksom på at æ, ø og å ikke må forekomme i et git alias. Derfor er æ, ø, å erstattet med ae, oe og aa. 
+
 # Ordliste
 
 ## fastlægge

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Man skal desuden være opmærksom på, at man ved anvendelse af dansk terminolog
 Du kan få git på dansk i din terminal.
 Kør blot nedenstående, og du er hurtigt på vej væk fra cirkussproget.
 ```bash
-curl https://raw.githubusercontent.com/AlexanderNorup/git-paa-dansk/master/git-paa-dansk.sh | sh
+curl https://raw.githubusercontent.com/thorehusfeldt/git-paa-dansk/master/git-paa-dansk.sh | sh
 ```
 Brug herefter favoritter som `git puf` eller `git klandre` til at udføre dine opgaver.
 

--- a/git-paa-dansk.sh
+++ b/git-paa-dansk.sh
@@ -1,0 +1,130 @@
+#Git på Dansk.
+
+# Hale
+git config --global alias.hal pull
+git config --global alias.hale pull
+
+# Puffe
+git config --global alias.puf push
+git config --global alias.puffe push
+
+#Hente
+git config --global alias.hent fetch
+git config --global alias.hente fetch
+
+#Forgrene
+git config --global alias.forgren branch
+git config --global alias.forgren branch
+
+#Fastlægge
+git config --global alias.fastlag commit
+git config --global alias.fastlagge commit
+git config --global alias.fastleg commit
+git config --global alias.fastlegge commit
+git config --global alias.fastlaeg commit
+git config --global alias.fastlaegge commit
+#Alternativ måde at sige fastlægge på:
+git config --global alias.forpligt commit
+
+#Genbasere
+git config --global alias.genbase rebase
+git config --global alias.genbaser rebase
+git config --global alias.genbasere rebase
+
+#Flette
+git config --global alias.flet merge
+git config --global alias.flette merge
+
+#Skifte
+git config --global alias.skift switch
+git config --global alias.skifte switch
+
+#Opmærke
+git config --global alias.opmaerke tag
+git config --global alias.opmerke tag
+git config --global alias.opmarke tag
+git config --global alias.opmark tag
+git config --global alias.opmerk tag
+git config --global alias.opmaerk tag
+
+#Håndplukke
+git config --global alias.pluk cherry-pick
+git config --global alias.plukke cherry-pick
+git config --global alias.handpluk cherry-pick
+git config --global alias.handplukke cherry-pick
+git config --global alias.haandpluk cherry-pick
+git config --global alias.haandplukke cherry-pick
+git config --global alias.hand-pluk cherry-pick
+git config --global alias.hand-plukke cherry-pick
+git config --global alias.haand-pluk cherry-pick
+git config --global alias.haand-plukke cherry-pick
+
+#Klandre
+git config --global alias.klandre blame
+git config --global alias.klandr blame
+git config --global alias.skyld blame
+
+#Nye tilføjelser
+git config --global alias.klon clone
+git config --global alias.nulstil reset
+git config --global alias.diff forskel
+git config --global alias.tilfoj add
+git config --global alias.tilfoej add
+git config --global alias.fjern rm
+git config --global alias.slet rm
+
+
+echo "
+============
+GIT PÅ DANSK
+============
+
+Tillykke du har nu fået Git på Dansk!
+Benyt følgende link til reference:
+https://github.com/thorehusfeldt/git-paa-dansk/blob/master/README.md
+
+Eller er her en kort liste:
++-------------+------------+
+| Engelsk     | Dansk      |
++-------------+------------+
+| pull        | hale       |
++-------------+------------+
+| push        | puffe      |
++-------------+------------+
+| fetch       | hente      |
++-------------+------------+
+| branch      | forgrene   |
++-------------+------------+
+|             | fastlaegge |
+| commit      |   (eller)  |
+|             | forpligt   |
++-------------+------------+
+| rebase      | genbasere  |
++-------------+------------+
+| merge       | flette     |
++-------------+------------+
+| stash       | gemme      |
++-------------+------------+
+| switch      | skifte     |
++-------------+------------+
+| tag         | opmærke    |
++-------------+------------+
+| cherry-pick | handplukke |
++-------------+------------+
+| blame       | klandre    |
++-------------+------------+
+| clone       | klon       |
++-------------+------------+
+| reset       | nulstil    |
++-------------+------------+
+| add         | tilfoej    |
++-------------+------------+
+| rm          | slet       |
++-------------+------------+
+
+Bemærk venligst at æ, ø og å ikke må forekomme i et git alias. Derfor er æøå erstattet med ae, oe og aa. 
+Det er også muligt at bruge bydeform af de danske ord. Så f.eks. \"puf\" kan bruges istedet for \"puffe\" osv.
+"
+
+
+


### PR DESCRIPTION
Git på dansk er sjovt, men hvad er der ved det hvis vi rent faktisk ikke kan `puffe` i vores terminaler?

Her en lille hale anmodning som tilføjer nogle kommandoer til gitkonsollen som aliases.

Har registeret alle de nævnte kommandoer, samt `klon`, `nulstil`, `forskel`, `tilfoej` og `slet`. Alle kommandoer er også registeret i bydeform, så man f.eks. kan køre `git puf` eller `git flet` i stedet for `git puffe` og `git flette`. Det løber lidt bedre af tungen.
