### PR TITLE
tilføjede opstrøms til oversigten + rettede en stavefejl

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Man skal desuden være opmærksom på, at man ved anvendelse af dansk terminolog
 | stash        | stash          | gemme        |
 | tag          | tag            | mærke        |
 
+|Biord         | Nuværende brug | Forslag      |
+|--------------|----------------|--------------|
+| upstream     | upstream       | opstrøms     |
+
 ## Eksempler
 
     - Gider I hale fra den gren, jeg lige har genbaseret og puffet til GitHub?
@@ -52,6 +56,8 @@ Man skal desuden være opmærksom på, at man ved anvendelse af dansk terminolog
     - Hov, jeg tvangspuffede vistnok til hovedgrenen!
 
     - Husk at kvase dine fastlæggelser, inden du fletter.
+    
+    - Hvis du har gaflet min gren skal du lige huske at hente opstrøms.
 
 
 # Ordliste
@@ -294,7 +300,7 @@ en reference, oftest til en fastlæggelse, som beskriver et bestemt punkt i udvi
 
 = mærke op
 
-forsyne en fastlæggelse med ett mærke.
+forsyne en fastlæggelse med et mærke.
 
 `BØJNING` -r, -de, -t   
 `GRAMMATIK` verbum, *nogen* opmærker *en fastlæggelse*  


### PR DESCRIPTION
Ordet "opstrøms" tilføjet til oversigten som et forslag til oversættelse af ordet "upstream".

tilføjede et eksempel der bruger ordene "opstrøms" og "gaflet"

ændrede ordet "ett" på linje 303 til "et".