### PR TITLE
Opdaterede den grammatiske sektion for hale

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ gennemføre ændringerne fra en gren påny, men fra en andet udgangspunkt end de
 
 `BØJNING` -r, -de, -t  
 `UDTALE` [ˈhɑlə]  
-`GRAMMATIK` verbum, *nogen* gafler *noget*  
+`GRAMMATIK` verbum, *nogen* haler *noget*  
 `ENGELSK` *pull*  
 `OPRINDELSE`  alm. i betydningen »trække langsomt og jævnt«, fra middelnedertysk *halen*, beslægtet med hole »hente hjem«  
 `ALTERNATIV` trække  


### PR DESCRIPTION
I den grammatiske sektion for hale står der på nuværende tidspunkt "nogen *gafler* noget", dette virker som en fejl, og det var meningen at der skulle stå "nogen *haler* noget"